### PR TITLE
expose fetching liked tweets in scraper

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -58,6 +58,9 @@ import {
   getArticle,
   getAllRetweeters,
   Retweeter,
+  fetchLikedTweets,
+  getLikedTweets,
+  getLikedTweetsByUserId,
 } from './tweets';
 import {
   parseTimelineTweetsV2,
@@ -576,6 +579,47 @@ export class Scraper {
     maxTweets = 200,
   ): AsyncGenerator<Tweet, void> {
     return getTweetsAndRepliesByUserId(userId, maxTweets, this.auth);
+  }
+
+  /**
+   * Fetches liked tweets from a Twitter user.
+   * @param userId The user whose liked tweets should be returned.
+   * @param maxTweets The maximum number of tweets to return. Defaults to `200`.
+   * @param cursor The search cursor, which can be passed into further requests for more results.
+   * @returns A page of results, containing a cursor that can be used in further requests.
+   */
+  public fetchLikedTweets(
+    userId: string,
+    maxTweets: number,
+    cursor?: string,
+  ): Promise<QueryTweetsResponse> {
+    return fetchLikedTweets(userId, maxTweets, cursor, this.auth);
+  }
+
+  /**
+   * Fetches liked tweets from a Twitter user.
+   * @param user The user whose liked tweets should be returned.
+   * @param maxTweets The maximum number of tweets to return. Defaults to `200`.
+   * @returns An {@link AsyncGenerator} of liked tweets from the provided user.
+   */
+  public getLikedTweets(
+    user: string,
+    maxTweets = 200,
+  ): AsyncGenerator<Tweet, void> {
+    return getLikedTweets(user, maxTweets, this.auth);
+  }
+
+  /**
+   * Fetches liked tweets from a Twitter user using their ID.
+   * @param userId The user whose liked tweets should be returned.
+   * @param maxTweets The maximum number of tweets to return. Defaults to `200`.
+   * @returns An {@link AsyncGenerator} of liked tweets from the provided user.
+   */
+  public getLikedTweetsByUserId(
+    userId: string,
+    maxTweets = 200,
+  ): AsyncGenerator<Tweet, void> {
+    return getLikedTweetsByUserId(userId, maxTweets, this.auth);
   }
 
   /**

--- a/src/tweets.ts
+++ b/src/tweets.ts
@@ -392,8 +392,8 @@ export function parseTweetV2ToV1(
       end_datetime: poll.end_datetime
         ? poll.end_datetime
         : defaultTweetData?.poll?.end_datetime
-          ? defaultTweetData?.poll?.end_datetime
-          : undefined,
+        ? defaultTweetData?.poll?.end_datetime
+        : undefined,
       options: poll.options.map((option) => ({
         position: option.position,
         label: option.label,
@@ -496,7 +496,7 @@ export async function createCreateTweetRequest(
   };
 
   if (hideLinkPreview) {
-    variables["card_uri"] = "tombstone://card"
+    variables['card_uri'] = 'tombstone://card';
   }
 
   if (mediaData && mediaData.length > 0) {
@@ -584,7 +584,7 @@ export async function createCreateNoteTweetRequest(
   tweetId?: string,
   mediaData?: { data: Buffer; mediaType: string }[],
 ) {
-  const twitterUrl = "https://twitter.com"
+  const twitterUrl = 'https://twitter.com';
 
   const cookies = await auth.cookieJar().getCookies(twitterUrl);
   const xCsrfToken = cookies.find((cookie) => cookie.key === 'ct0');
@@ -820,6 +820,34 @@ export async function fetchLikedTweets(
   }
 
   return parseTimelineTweetsV2(res.value);
+}
+
+export function getLikedTweets(
+  user: string,
+  maxTweets: number,
+  auth: TwitterAuth,
+): AsyncGenerator<Tweet, void> {
+  return getTweetTimeline(user, maxTweets, async (q, mt, c) => {
+    const userIdRes = await getUserIdByScreenName(q, auth);
+
+    if (!userIdRes.success) {
+      throw userIdRes.err;
+    }
+
+    const { value: userId } = userIdRes;
+
+    return fetchLikedTweets(userId, mt, c, auth);
+  });
+}
+
+export function getLikedTweetsByUserId(
+  userId: string,
+  maxTweets: number,
+  auth: TwitterAuth,
+): AsyncGenerator<Tweet, void> {
+  return getTweetTimeline(userId, maxTweets, (q, mt, c) => {
+    return fetchLikedTweets(q, mt, c, auth);
+  });
 }
 
 export async function getTweetWhere(
@@ -1059,9 +1087,12 @@ async function uploadMedia(
   } else {
     // Handle image upload
     const form = new FormData();
-    form.append('media', new Blob([mediaData], {
-      type: mediaType,
-    }));
+    form.append(
+      'media',
+      new Blob([mediaData], {
+        type: mediaType,
+      }),
+    );
 
     const response = await fetch(uploadUrl, {
       method: 'POST',
@@ -1412,7 +1443,7 @@ export async function createCreateLongTweetRequest(
   // URL for the long tweet endpoint
   const url =
     'https://x.com/i/api/graphql/YNXM2DGuE2Sff6a2JD3Ztw/CreateNoteTweet';
-  const twitterUrl = "https://twitter.com"
+  const twitterUrl = 'https://twitter.com';
 
   const cookies = await auth.cookieJar().getCookies(twitterUrl);
   const xCsrfToken = cookies.find((cookie) => cookie.key === 'ct0');
@@ -1582,7 +1613,8 @@ export async function fetchRetweetersPage(
     creator_subscriptions_quote_tweet_preview_enabled: false,
     freedom_of_speech_not_reach_fetch_enabled: true,
     standardized_nudges_misinfo: true,
-    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled:
+      true,
     rweb_video_timestamps_enabled: true,
     longform_notetweets_rich_text_read_enabled: true,
     longform_notetweets_inline_media_enabled: true,
@@ -1676,7 +1708,7 @@ export async function fetchRetweetersPage(
  */
 export async function getAllRetweeters(
   tweetId: string,
-  auth: TwitterAuth
+  auth: TwitterAuth,
 ): Promise<Retweeter[]> {
   let allRetweeters: Retweeter[] = [];
   let cursor: string | undefined;
@@ -1687,7 +1719,7 @@ export async function getAllRetweeters(
       tweetId,
       auth,
       cursor,
-      40
+      40,
     );
     allRetweeters = allRetweeters.concat(retweeters);
 


### PR DESCRIPTION
While seeing others' likes was removed from X, it's still possible to get the logged in user's likes. 

Test script:
```
import { Scraper } from './dist/node/cjs/index.cjs';

async function testLikedTweets() {
  const scraper = new Scraper();

  const cookies = [...];

  await scraper.setCookies(cookies);

  const profile = await scraper.me();
  const userId = profile?.userId;

  if (!userId) {
    throw new Error('Could not get user ID');
  }

  const likedTweets = await scraper.fetchLikedTweets(userId, 1);

  if (likedTweets.tweets.length > 0) {
    const tweet = likedTweets.tweets[0];
    console.log(`@${tweet.username}: ${tweet.text}`);
  } else {
    console.log('No liked tweets found');
  }
}

testLikedTweets().catch(console.error);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch liked tweets for Twitter users by username or user ID, with support for pagination and streaming results.

- **Style**
  - Improved code formatting for consistency, including string literal styles and trailing commas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->